### PR TITLE
Fix typo & add link to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Product Design Documentation
 
-On the Product Design team at BuzzFeed, we believe in internal transparency, as well as sharing with the wider community. This git repo will, hopefully, serve both purposes. For our Product Design team, our documentation will live and evolve here, allowing us to easily see and diff changes to our documents over time. For the wider Product Design and Tech community, we hope that sharing this repo will inspire others, generate conversation at other companies and also give us more ideas for how to evolve our own work.
+On the Product Design team at BuzzFeed, we believe in internal transparency, as well as sharing with the wider community. This git repo will, hopefully, serve both purposes. For our Product Design team, our documentation will live and evolve here, allowing us to easily see and diff changes to our documents over time. For the wider Product Design and Tech community, we hope that sharing this repo will inspire others, generate conversation at other companies, and give us more ideas for how to evolve our own work.
 
-This project is licensed under the terms of the GNU Free Documentation License.
+This project is licensed under the terms of the <a href = "https://www.gnu.org/licenses/licenses.html#FDL" > GNU Free Documentation License</a>.


### PR DESCRIPTION
"also" is redundant and license lets readers get to the specifics if desired.