### PR TITLE
Update tech leadership principles

### DIFF
--- a/tech-leadership-principles.md
+++ b/tech-leadership-principles.md
@@ -13,11 +13,14 @@ At BuzzFeed we recognize that communication is a critical factor in the success 
 ## Follow Through
 We do what we say we will. At BuzzFeed, when we commit, we commit fully and deliver on time, and communicate proactively if we need more time or help.
 
+## Hold Strong Opinions and Low Ego
+As leaders, we have a strong point of view and advocate for our opinions. We push ourselves and our teams to do the best work possible by being vocal when we disagree and backing up our opinions with sound logic. At the same time, we strive to discover and support the best idea. We are open to our own ideas evolving and recognize that, once a decision has been made, we must commit fully to keep the team moving forward.
+
 ## Invest Strategically
 We are always aware of how ourselves and our teams spend their time and attention. We ensure that the conditions and processes are right for great work to happen, on timelines that allow that work to happen. If we find ourselves working against an overly-aggressive timeline or crunching to meet a deadline, we stop and evaluate the way we’re planning and staffing our work so that we can execute at a high-level without running the risk of burnout or shipping hurried, bad work.
 
-## Measure Impact
-Our products are only as important as the impact they have on the people who use them. As leaders, we evaluate any proposed project by its potential impact - whether that's impact on our audience, business or even our culture - and what we can measure to ensure we achieve that impact. We set clear, measurable goals and keep ourselves and our teams focused on those at every step throughout a project. If our products and processes don't achieve meaningful impact, we either give ourselves space to iterate and try new approaches, or we gracefully shelve the product and move on to other ideas.
+## Bias for Impact
+Our products are only as important as the impact they have on the people who use them. As leaders, we seize opportunities with the best data available and go after work that generates the most value for the greatest number of users. We avoid over-optimization at a local level, and instead always try to think globally about our audiences and products, and also remain flexible as our audience and product needs change. We believe that our internal processes are tools to help us create value, and that if we’re being hindered by our own process we should question and then change or remove it from our project.
 
 ## Practice Generosity
 We are always looking for opportunities to share our experience with people around us. Whether mentoring or sponsoring a colleague, helping out when someone is stuck or teaching our craft to a coworker from another department, we are generous with our knowledge and our time, because it makes us better collaborators and people.
@@ -25,17 +28,11 @@ We are always looking for opportunities to share our experience with people arou
 ## Raise the Bar
 We hold ourselves and each other to high standards, and are always on the lookout for ways to improve our skill sets, our products and our culture. We regularly challenge our anchors, and endeavor to raise the level of execution and discourse across our teams and all of Tech: whether by questioning the goals of a proposed or ongoing project, seeding and leading new Tech-wide initiatives, running retrospectives to find potential future adjustments or helping out colleagues from other departments.
 
-## Ship Great Products
-Whether we're working on products for our coworkers, the BuzzFeed audience, or running an experiment on a small percentage of our overall audience, we make decisions that balance speed with maintaining the integrity of our products and user experience. If we’re asked to intentionally take tech debt or “cut corners”, we thoughtfully consider how that decision will this impact the user, the project, and our team’s morale.
-
-## Stay Flexible
-We recognize that one of BuzzFeed’s greatest strengths is our ability to embrace, pursue and adapt ourselves to change. As leaders, we care deeply about the products we work on, without being precious about those products or our own ideas. This means that whether there’s a shift in company strategy, adjustments to priorities for our team, or pivots to our roadmaps after an A/B test or research session, our focus is always on doing what is best for BuzzFeed and our audience.
-
-## Hold Strong Opinions and Low Ego
-As leaders, we have a strong point of view and advocate for our opinions. We push ourselves and our teams to do the best work possible by being vocal when we disagree and backing up our opinions with sound logic. At the same time, we strive to discover and support the best idea. We are open to our own ideas evolving and recognize that, once a decision has been made, we must commit fully to keep the team moving forward.
+## Ship It and Learn
+Leaders at BuzzFeed know that we need to move quickly to achieve our goals, and excel at breaking big ideas down into smaller, measurable, individually-valuable pieces that can be shipped to users and inform future work. We work to keep ourselves and our teams focused and shipping on a regular cadence, so that we consistently deliver new value to our users and maintain momentum so that we can achieve our larger, long-term goals.
 
 ## Take Responsibility
 You’ll never hear, “That’s not my job,” or “That’s someone else’s fault,” from a leader at BuzzFeed. We are quick to jump in and help people, and frequently engage with other teams, disciplines and parts of the product. When we see an opportunity to solve problems - in the product, on our team or in the culture - we dive in headfirst and get the right people involved. And when things go wrong, we take responsibility and ownership rather than pass the blame onto others.
 
-## Value Breadth of Knowledge
-As leaders, we work to develop skills in areas orthogonal to our own discipline. Whether we are an engineer delving more into data science, a designer getting to know our business strategy or a data scientist attending an editorial brainstorm, we relish opportunities to more deeply understand other functions and areas of expertise so that we can work better together and be more informed in our own decision-making.
+## Pursue Domain Expertise
+As leaders, we are experts in our assigned product area, developing a deep understanding of our audience, external industry trends, key stakeholders across the company, and the business strategy surrounding our product. When successful, the problems of our stakeholders and users become our problems and we become trusted partners with other departments at BuzzFeed. We use our expertise and the trust we’ve built not only to inform our product work, but to also inform our business leaders, content creators and other collaborators so that they can make better, more data-driven decisions.


### PR DESCRIPTION
Tech leadership principles were changed by tech leadership in 2018.  This update reflects those changes for consistency in evaluations.

Added: Ship It and Learn
Added: Pursue Domain Expertise
Added: Bias For Impact
Removed: Ships Great Products
Removed: Stay Flexible
Removed: Measure Impact